### PR TITLE
Add ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,74 @@
+version: 2.1
+orbs:
+  python: circleci/python@2.0.3
+
+definitions:
+  install-args: &install-args
+      pkg-manager: pip-dist
+      pip-dependency-file: requirements-dev.txt
+      args: --requirement requirements-dev.txt
+
+jobs:
+  lint:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - python/install-packages: *install-args
+      - run:
+          command: |
+            cp .pre-commit-config.yaml pre-commit-cache-key.txt
+            python --version --version >> pre-commit-cache-key.txt
+      - restore_cache:
+          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+      - run: pre-commit run --all-files --show-diff-on-failure
+      - save_cache:
+          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+          paths:
+            - ~/.cache/pre-commit
+  unit-tests:
+    parameters:
+      version:
+        type: string
+    docker:
+      - image: cimg/python:<< parameters.version >>
+    steps:
+      - checkout
+      - python/install-packages: *install-args
+      - run:
+          name: Run unit tests
+          command: coverage run --module pytest
+      - run: coverage report
+
+  end-to-end-tests:
+    parameters:
+      version:
+        type: string
+    docker:
+      - image: cimg/python:<< parameters.version >>
+    steps:
+      - checkout
+      # I want to install into a virtualenv
+      - python/install-packages: *install-args
+      - run:
+          name: Install mock dependencies
+          command: |
+            # To keep things simple, don't bother installing virtualenvs
+            poetry config virtualenvs.create false
+            tests/end_to_end/data/install_all.sh
+      - run:
+          name: Run end-to-end tests
+          command: pytest tests/end_to_end
+
+workflows:
+  test-and-lint:
+    jobs:
+      - unit-tests:
+          matrix:
+            parameters:
+              version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+      - end-to-end-tests:
+          matrix:
+            parameters:
+              version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+      - lint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+# Auto generated hash from ./scripts/add-dependencies-hash.sh
+# 0387ba0e3cc913af62470f6b7d4517ca46f38ad99a9d7d02a478d7eebb07ba1f
 pytest
 pre-commit
 coverage

--- a/scripts/add-dependencies-hash.sh
+++ b/scripts/add-dependencies-hash.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Build a hash for dependencies in setup.cfg and requirements-dev.txt
+# just for CI caching
+# this should be run any time dependencies are updated
+
+set -o errexit -o pipefail -o nounset
+
+install_requires="$(python -c '\
+    from configparser import ConfigParser; \
+    config = ConfigParser(); \
+    config.read("setup.cfg"); \
+    print(config["options"]["install_requires"]) \
+')"
+
+deps_hash="$(
+    echo "$install_requires" \
+    | cat requirements-dev.txt - \
+    | sha256sum - \
+    | awk '{print $1}'
+)"
+
+printf "# Auto generated hash from $0\n# $deps_hash\n" >> requirements-dev.txt.new
+cat requirements-dev.txt >> requirements-dev.txt.new
+mv requirements-dev.txt.new requirements-dev.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,3 +77,8 @@ omit = tests/end_to_end/*
 source =
     unused_deps/
     tests/
+
+[coverage:report]
+show_missing = true
+skip_covered = true
+fail_under = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ install_requires =
 python_requires = >=3.7,<3.11
 
 [options.packages.find]
-where = src
 exclude =
     tests*
     scripts/*
@@ -76,5 +75,5 @@ profile = black
 plugins = covdefaults
 omit = tests/end_to_end/*
 source =
-    src/
+    unused_deps/
     tests/

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ profile = black
 
 [coverage:run]
 plugins = covdefaults
+branch = true
 omit = tests/end_to_end/*
 source =
     unused_deps/

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ python_requires = >=3.7,<3.11
 where = src
 exclude =
     tests*
+    scripts/*
 
 [options.package_data]
 unused_deps = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 
@@ -21,7 +22,7 @@ install_requires =
     importlib-metadata>=1.0.0;python_version<="3.7"
     tomli;python_version<="3.11"
     packaging
-python_requires = >=3.7,<3.11
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =

--- a/tests/end_to_end/data/install_all.sh
+++ b/tests/end_to_end/data/install_all.sh
@@ -19,7 +19,7 @@ do
     if [ -e "pyproject.toml" ]
     then
         # --quiet suppresses error messages
-        poetry install --all-extras
+        poetry install --no-ansi --all-extras
     fi
 done
 


### PR DESCRIPTION
- Add script to build hash for dependencies

    Dependencies for installing and testing/linting are split across
    `setup.cfg` and `requirements-dev.txt` but CircleCI doesn't allow
    specifying several files to hash for caching[1]. So add a script that
    builds a hash from concatenating these two sources of dependencies and
    prepends it to `requirements-dev.txt` so we can just hash that file for
    the key.

    [1] https://github.com/CircleCI-Public/python-orb/issues/78

- Remove references to `src/` in `setup.cfg`

- Add settings for coverage reporting

- Add CI configuration for testing and linting

    CircleCI's python orb doesn't have nice support for running things via
    `coverage` so had to add some steps for this. I could've worked around
    to keep things simpler with `pytest-cov`