### PR TITLE
Cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
       - image: cimg/python:<< parameters.version >>
     steps:
       - checkout
-      # I want to install into a virtualenv
       - python/install-packages: *install-args
       - run:
           name: Install mock dependencies

--- a/README.md
+++ b/README.md
@@ -17,19 +17,22 @@ $ py-unused-deps
 
 ## Usage
 
-    usage: py-unused-deps [-h] [-d DISTRIBUTION] [-v] [-i IGNORE] [-s SOURCE] [-e EXTRA]
-    
+    usage: py-unused-deps [-h] [-d DISTRIBUTION] [-v] [-i IGNORE] [-s SOURCE] [-e EXTRA] [-r REQUIREMENT]
+
     options:
       -h, --help            show this help message and exit
       -d DISTRIBUTION, --distribution DISTRIBUTION
                             The distribution to scan for unused dependencies
       -v, --verbose
       -i IGNORE, --ignore IGNORE
-                            Dependencies to ignore when scanning for usage. For example, you might want to ignore a linter that you run but don't import
+                            Dependencies to ignore when scanning for usage. For example, you might want to ignore a linter that you run but
+                            don't import
       -s SOURCE, --source SOURCE
                             Extra directories to scan for python files to check for dependency usage
       -e EXTRA, --extra EXTRA
                             Extra environment to consider when loading dependencies
+      -r REQUIREMENT, --requirement REQUIREMENT
+                            File listing extra requirements to scan for
 
 ### Distribution detection
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = unused-deps
+name = py-unused-deps
 version = 0.0.1
 author = Matthew Hughes
 author_email = matthewhughes934@gmail.com


### PR DESCRIPTION
- Remove forgotten comment

- Update usage in README

- Update distribution name

    I don't really see a reason for the naming difference between the
    distribution and the entrypoint name.