### PR TITLE
CI add self run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,14 @@ jobs:
           name: Run end-to-end tests
           command: pytest tests/end_to_end
 
+  self-run:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - python/install-packages: *install-args
+      - run: py-unused-deps
+
 workflows:
   test-and-lint:
     jobs:
@@ -71,3 +79,4 @@ workflows:
             parameters:
               version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       - lint
+      - self-run

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,6 @@ unused_deps = py.typed
 console_scripts =
     py-unused-deps = unused_deps.main:main
 
-[options.extras_require]
-foo = bar>=1.2
-
 [mypy]
 strict = true
 exclude = ^setup\.py$


### PR DESCRIPTION
- Remove misplaced extra dependency

    I think this is a relic from some earlier testing I was doing

- Add a run of `py-unused-deps` in CI

    Both to check things work and so we don't include any unused
    dependencies
