### PR TITLE
Rewrite logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - checkout
       - python/install-packages: *install-args
-      - run: py-unused-deps
+      - run: py-unused-deps unused_deps
 
 workflows:
   test-and-lint:

--- a/tests/end_to_end/end_to_end_test.py
+++ b/tests/end_to_end/end_to_end_test.py
@@ -21,13 +21,17 @@ def as_cwd(path: Path) -> Generator[None, None, None]:
 
 
 @pytest.mark.parametrize(
-    "package_name", ("setuptools-dist-all-deps", "poetry-dist-all-deps")
+    ("package_name", "filepath"),
+    (
+        ("setuptools-dist-all-deps", "setuptools_all_deps.py"),
+        ("poetry-dist-all-deps", "poetry_all_deps"),
+    ),
 )
-def test_setuptools_with_all_deps(capsys, package_name):
+def test_setuptools_with_all_deps(capsys, package_name, filepath):
     package_dir = Path(__file__).parent / "data" / "test_pkg_with_all_deps"
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name])
+        returncode = main(["--distribution", package_name, filepath])
 
     captured = capsys.readouterr()
     assert returncode == 0
@@ -36,13 +40,17 @@ def test_setuptools_with_all_deps(capsys, package_name):
 
 
 @pytest.mark.parametrize(
-    "package_name", ("setuptools-dist-missing-a-dep", "poetry-dist-missing-a-dep")
+    ("package_name", "filepath"),
+    (
+        ("setuptools-dist-missing-a-dep", "setuptools_missing_dep.py"),
+        ("poetry-dist-missing-a-dep", "poetry_missing_dep"),
+    ),
 )
-def test_simple_package_missing_dep(capsys, package_name):
+def test_simple_package_missing_dep(capsys, package_name, filepath):
     package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep"
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name])
+        returncode = main(["--distribution", package_name, filepath])
 
     captured = capsys.readouterr()
     assert returncode == 1
@@ -51,13 +59,17 @@ def test_simple_package_missing_dep(capsys, package_name):
 
 
 @pytest.mark.parametrize(
-    "package_name", ("setuptools-nested-dist-all-deps", "poetry-nested-dist-all-deps")
+    ("package_name", "filepath"),
+    (
+        ("setuptools-nested-dist-all-deps", "setuptools_src"),
+        ("poetry-nested-dist-all-deps", "poetry_src"),
+    ),
 )
-def test_setuptools_nested_with_all_deps(capsys, package_name):
+def test_setuptools_nested_with_all_deps(capsys, package_name, filepath):
     package_dir = Path(__file__).parent / "data" / "test_pkg_nested_with_all_deps"
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name])
+        returncode = main(["--distribution", package_name, filepath])
 
     captured = capsys.readouterr()
     assert returncode == 0
@@ -70,7 +82,7 @@ def test_package_with_deps_in_tests_without_extra_source(capsys):
     package_dir = Path(__file__).parent / "data" / "test_pkg_with_dep_in_tests"
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name])
+        returncode = main(["--distribution", package_name, "setuptools_deps_in_tests"])
 
     captured = capsys.readouterr()
     assert returncode == 1
@@ -83,7 +95,9 @@ def test_package_with_deps_in_tests_with_extra_source(capsys):
     package_dir = Path(__file__).parent / "data" / "test_pkg_with_dep_in_tests"
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, "--source", "tests/"])
+        returncode = main(
+            ["--distribution", package_name, "setuptools_deps_in_tests", "tests"]
+        )
 
     captured = capsys.readouterr()
     assert returncode == 0
@@ -92,14 +106,21 @@ def test_package_with_deps_in_tests_with_extra_source(capsys):
 
 
 @pytest.mark.parametrize(
-    "package_name",
-    ("setuptools-dist-missing-extra-dep", "poetry-dist-missing-extra-dep"),
+    ("package_name", "filepath"),
+    (
+        ("setuptools-dist-missing-extra-dep", "setuptools_missing_extra_dep.py"),
+        ("poetry-dist-missing-extra-dep", "poetry_missing_extra_dep"),
+    ),
 )
-def test_package_missing_extra_dep_fails_with_extra_specified(capsys, package_name):
+def test_package_missing_extra_dep_fails_with_extra_specified(
+    capsys, package_name, filepath
+):
     package_dir = Path(__file__).parent / "data" / "test_pkg_missing_extra_dep"
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, "--extra", "tests"])
+        returncode = main(
+            ["--distribution", package_name, "--extra", "tests", filepath]
+        )
 
     captured = capsys.readouterr()
     assert returncode == 1
@@ -108,17 +129,20 @@ def test_package_missing_extra_dep_fails_with_extra_specified(capsys, package_na
 
 
 @pytest.mark.parametrize(
-    "package_name",
-    ("setuptools-dist-missing-extra-dep", "poetry-dist-missing-extra-dep"),
+    ("package_name", "filepath"),
+    (
+        ("setuptools-dist-missing-extra-dep", "setuptools_missing_extra_dep.py"),
+        ("poetry-dist-missing-extra-dep", "poetry_missing_extra_dep"),
+    ),
 )
 @pytest.mark.parametrize("extra_args", ([], ["--extra", "something-else"]))
 def test_package_missing_extra_dep_passes_without_extra_specificed(
-    capsys, package_name, extra_args
+    capsys, package_name, filepath, extra_args
 ):
     package_dir = Path(__file__).parent / "data" / "test_pkg_missing_extra_dep"
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name] + extra_args)
+        returncode = main(["--distribution", package_name] + extra_args + [filepath])
 
     captured = capsys.readouterr()
     assert returncode == 0
@@ -127,21 +151,27 @@ def test_package_missing_extra_dep_passes_without_extra_specificed(
 
 
 @pytest.mark.parametrize(
-    "package_name",
+    ("package_name", "filepath"),
     (
-        "setuptools-dist-missing-a-dep-in-requirements",
-        "poetry-dist-missing-a-dep-in-requirements",
+        (
+            "setuptools-dist-missing-a-dep-in-requirements",
+            "setuptools_missing_dep_in_requirements.py",
+        ),
+        (
+            "poetry-dist-missing-a-dep-in-requirements",
+            "poetry_missing_dep_in_requirements",
+        ),
     ),
 )
 def test_package_missing_dep_in_requirements_no_error_without_requirements_specified(
-    capsys, package_name
+    capsys, package_name, filepath
 ):
     package_dir = (
         Path(__file__).parent / "data" / "test_pkg_missing_dep_in_requirements"
     )
 
     with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name])
+        returncode = main(["--distribution", package_name, filepath])
 
     captured = capsys.readouterr()
     assert returncode == 0
@@ -150,14 +180,20 @@ def test_package_missing_dep_in_requirements_no_error_without_requirements_speci
 
 
 @pytest.mark.parametrize(
-    "package_name",
+    ("package_name", "filepath"),
     (
-        "setuptools-dist-missing-a-dep-in-requirements",
-        "poetry-dist-missing-a-dep-in-requirements",
+        (
+            "setuptools-dist-missing-a-dep-in-requirements",
+            "setuptools_missing_dep_in_requirements.py",
+        ),
+        (
+            "poetry-dist-missing-a-dep-in-requirements",
+            "poetry_missing_dep_in_requirements",
+        ),
     ),
 )
 def test_package_missing_dep_in_requirements_reports_missing_when_pass_requirements(
-    capsys, package_name
+    capsys, package_name, filepath
 ):
     package_dir = (
         Path(__file__).parent / "data" / "test_pkg_missing_dep_in_requirements"
@@ -165,7 +201,13 @@ def test_package_missing_dep_in_requirements_reports_missing_when_pass_requireme
 
     with as_cwd(package_dir):
         returncode = main(
-            ["--distribution", package_name, "--requirement", "requirements.txt"]
+            [
+                "--distribution",
+                package_name,
+                "--requirement",
+                "requirements.txt",
+                filepath,
+            ]
         )
 
     captured = capsys.readouterr()

--- a/tests/files_test.py
+++ b/tests/files_test.py
@@ -1,0 +1,84 @@
+import os
+
+import pytest
+
+from unused_deps.files import find_files
+
+
+def _normalize_path(path):
+    return path.replace("/", os.path.sep)
+
+
+def _normalize_paths(*paths):
+    return tuple(_normalize_path(path) for path in paths)
+
+
+def test_find_files_includes_bare_filename(tmpdir):
+    path = tmpdir.join(_normalize_path("some/file.py")).ensure()
+    expected = (path,)
+
+    got = tuple(find_files(path, exclude=(), include=(path,)))
+
+    assert len(got) == len(expected)
+    assert set(got) == set(expected)
+
+
+@pytest.mark.parametrize(
+    ("paths", "include", "exclude", "expected"),
+    (
+        pytest.param(
+            ("file.py",), ("*.py",), (), ("file.py",), id="Simple prefix include"
+        ),
+        pytest.param(
+            ("file.sh",),
+            ("*.py",),
+            (),
+            (),
+            id="Include with no match",
+        ),
+        pytest.param(("file.py",), (), ("*.py",), (), id="Simple prefix exclude"),
+        pytest.param(
+            ("file.py", "other.py"),
+            ("*.py",),
+            ("other.py",),
+            ("file.py",),
+            id="Mixed include/exclude",
+        ),
+        pytest.param(
+            _normalize_paths("dir/file.py"),
+            ("*.py",),
+            (),
+            _normalize_paths("dir/file.py"),
+            id="Simple prefix include subdir",
+        ),
+        pytest.param(
+            _normalize_paths("dir/file.py"),
+            (),
+            ("*.py",),
+            (),
+            id="Simple prefix exclude subdir",
+        ),
+        pytest.param(
+            _normalize_paths("dir/file1.py", "dir/file2.py", "dir/foo/file3.py"),
+            ("*.py",),
+            ("dir",),
+            (),
+            id="Exclude directory",
+        ),
+        pytest.param(
+            _normalize_paths("dir/file1.py", "dir/file2.py", "dir2/bar.py"),
+            ("*.py",),
+            ("dir",),
+            _normalize_paths("dir2/bar.py"),
+            id="Mixed include/exclude dir",
+        ),
+    ),
+)
+def test_find_files(tmpdir, paths, include, exclude, expected):
+    for path in paths:
+        tmpdir.join(path).ensure()
+
+    got = tuple(find_files(tmpdir, exclude=exclude, include=include))
+
+    assert len(got) == len(expected)
+    assert set(got) == set(tmpdir.join(path) for path in expected)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -19,9 +19,8 @@ class TestMain:
             (["--verbose", "--verbose", "--verbose"], logging.DEBUG),
         ),
     )
-    def test_logging_level_set_from_args(self, tmpdir, args, expected_logging_level):
-        with tmpdir.as_cwd():
-            main(args)
+    def test_logging_level_set_from_args(self, args, expected_logging_level):
+        main(args)
 
         logger = logging.getLogger("unused-deps")
         assert logger.getEffectiveLevel() == expected_logging_level
@@ -60,7 +59,7 @@ class TestMain:
         )
 
     @pytest.mark.parametrize("filenames", ([], ["not_python.c"]))
-    def test_logs_on_package_with_no_source_files(self, filenames, caplog):
+    def test_logs_on_package_with_no_source_files(self, filenames, caplog, tmpdir):
         root_package = "my-package"
         root_dist = InMemoryDistribution({filename: [] for filename in filenames})
         mock_dist = mock.Mock(**{"from_name.return_value": root_dist})
@@ -68,7 +67,7 @@ class TestMain:
 
         with caplog.at_level(logging.INFO), mock.patch(
             "unused_deps.main.importlib_metadata.Distribution", mock_dist
-        ):
+        ), tmpdir.as_cwd():
             returncode = main(argv)
 
         assert returncode == 0

--- a/unused_deps/files.py
+++ b/unused_deps/files.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator, Sequence
+from fnmatch import fnmatch
+
+
+# TODO: default includes: *.py, *.pyi
+# TODO: default excludes: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,*.egg,.venv,venv
+def find_files(
+    path: str, *, exclude: Sequence[str], include: Sequence[str]
+) -> Generator[str, None, None]:
+    return (
+        filename
+        for filename in _walk_path(path, exclude)
+        if _include(filename, include)
+    )
+
+
+def _walk_path(path: str, exclude: Sequence[str]) -> Generator[str, None, None]:
+    if os.path.isdir(path):
+        for root, sub_directories, files in os.walk(path):
+            for directory in tuple(sub_directories):
+                joined = os.path.join(root, directory)
+                if _exclude(joined, exclude):
+                    sub_directories.remove(directory)
+
+            for filename in files:
+                joined = os.path.join(root, filename)
+                if not _exclude(joined, exclude):
+                    yield joined
+    else:
+        yield path
+
+
+def _include(path: str, globs: Sequence[str]) -> bool:
+    return any(path == glob or fnmatch(path, glob) for glob in globs)
+
+
+def _exclude(path: str, exclude: Sequence[str]) -> bool:
+    basename = os.path.basename(path)
+    abs_path = os.path.abspath(path)
+
+    return any(
+        fnmatch(basename, pattern) or fnmatch(abs_path, pattern) for pattern in exclude
+    )

--- a/unused_deps/import_finder.py
+++ b/unused_deps/import_finder.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from os import PathLike
 
 
-def get_import_bases(path: PathLike[str]) -> Generator[str, None, None]:
+def get_import_bases(path: str) -> Generator[str, None, None]:
     with open(path) as f:
         file_contents = f.read()
 

--- a/unused_deps/main.py
+++ b/unused_deps/main.py
@@ -24,50 +24,8 @@ logger = logging.getLogger("unused-deps")
 def main(argv: Sequence[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
-    parser = argparse.ArgumentParser()
 
-    parser.add_argument(
-        "-d",
-        "--distribution",
-        required=False,
-        help="The distribution to scan for unused dependencies",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        default=0,
-        action="count",
-    )
-    parser.add_argument(
-        "-i",
-        "--ignore",
-        required=False,
-        action="append",
-        help="Dependencies to ignore when scanning for usage. "
-        "For example, you might want to ignore a linter that you run but don't import",
-    )
-    parser.add_argument(
-        "-s",
-        "--source",
-        required=False,
-        action="append",
-        help="Extra directories to scan for python files to check for dependency usage",
-    )
-    parser.add_argument(
-        "-e",
-        "--extra",
-        required=False,
-        action="append",
-        help="Extra environment to consider when loading dependencies",
-    )
-    parser.add_argument(
-        "-r",
-        "--requirement",
-        required=False,
-        action="append",
-        help="File listing extra requirements to scan for",
-    )
-
+    parser = _build_arg_parser()
     args = parser.parse_args(argv)
     _configure_logging(args.verbose)
 
@@ -152,3 +110,51 @@ def _read_requirements(
         with open(requirement_file) as f:
             for requirement in f:
                 yield parse_requirement(dist, requirement.rstrip(), extras)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-d",
+        "--distribution",
+        required=False,
+        help="The distribution to scan for unused dependencies",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        default=0,
+        action="count",
+    )
+    parser.add_argument(
+        "-i",
+        "--ignore",
+        required=False,
+        action="append",
+        help="Dependencies to ignore when scanning for usage. "
+        "For example, you might want to ignore a linter that you run but don't import",
+    )
+    parser.add_argument(
+        "-s",
+        "--source",
+        required=False,
+        action="append",
+        help="Extra directories to scan for python files to check for dependency usage",
+    )
+    parser.add_argument(
+        "-e",
+        "--extra",
+        required=False,
+        action="append",
+        help="Extra environment to consider when loading dependencies",
+    )
+    parser.add_argument(
+        "-r",
+        "--requirement",
+        required=False,
+        action="append",
+        help="File listing extra requirements to scan for",
+    )
+
+    return parser


### PR DESCRIPTION
- Add file discovery logic

    I want to move away from trying to discover package files from metadata,
    since:

    * I don't fully understand/want to handle all the ways packages can be
      stored (e.g. as plain files vs. zipped)
    * I don't want to have to deal with all the possible ways packages can
      be installed e.g. editable installs via `pip` vs poetry`

    So I'll use it to users to specify where we should discover paths like:

        $ py-unused deps --include="*.py" --exclude="tests" .

    This change just adds the basic file discovery logic and is inspired by
    how `flake8` handles this.

- Move arg building to a separate function

    This is to just keep main a bit clearer

- Update args for new approach

    Add `--include`, `--exclude` args and accept a list of file paths as
    positional arguments.

    There's a bunch of extra cleanup that can be done now, but this is just
    the minimal change to get things working.