### PR TITLE
Make distribution optional

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,8 +9,6 @@ from unused_deps.compat import importlib_metadata
 
 
 class InMemoryDistribution(importlib_metadata.Distribution):  # type: ignore[misc] # for py<3.8
-    dist_map: dict[str, dict[str, list[str]]] = {}
-
     def __init__(self, file_lines_map: Mapping[str, Iterable[str]]) -> None:
         self.file_map = {
             filename: StringIO("\n".join(lines))
@@ -43,21 +41,3 @@ class InMemoryDistribution(importlib_metadata.Distribution):  # type: ignore[mis
 
     def locate_file(self, path: str | os.PathLike[str]) -> os.PathLike[str]:
         raise NotImplementedError("Unimplemented unused abstractmethod")
-
-    @classmethod
-    def from_name(cls, name: str) -> InMemoryDistribution:
-        try:
-            return InMemoryDistribution(cls.dist_map[name])
-        except KeyError:
-            raise importlib_metadata.PackageNotFoundError(name)
-
-    def add_package(
-        self, name: str, file_map: Mapping[str, list[str]] | None = None
-    ) -> None:
-        if name in self.dist_map:  # pragma: no cover
-            raise ValueError(f"Package {name} already added")
-
-        self.dist_map[name] = {"METADATA": [f"name: {name}"]}
-
-        if file_map:
-            self.dist_map[name].update(file_map)

--- a/unused_deps/dist_info.py
+++ b/unused_deps/dist_info.py
@@ -33,13 +33,12 @@ def required_dists(
         return
 
     for raw_requirement in dist.requires:
-        req_dist = _dist_from_requirement(Requirement(raw_requirement), extras, dist)
+        req_dist = _dist_from_requirement(Requirement(raw_requirement), extras)
         if req_dist is not None:
             yield req_dist
 
 
 def parse_requirement(
-    dist: importlib_metadata.Distribution,
     raw_requirement: str,
     extras: Iterable[str] | None,
 ) -> importlib_metadata.Distribution | None:
@@ -55,7 +54,7 @@ def parse_requirement(
         logger.debug("Skipping requirement %s: %s", raw_requirement, e)
         return None
     else:
-        return _dist_from_requirement(requirement, extras, dist)
+        return _dist_from_requirement(requirement, extras)
 
 
 def _top_level_declared(dist: importlib_metadata.Distribution) -> list[str]:
@@ -73,10 +72,9 @@ def _top_level_inferred(dist: importlib_metadata.Distribution) -> set[str]:
 def _dist_from_requirement(
     requirement: Requirement,
     extras: Iterable[str] | None,
-    root_dist: importlib_metadata.Distribution,
 ) -> importlib_metadata.Distribution | None:
     try:
-        req_dist = root_dist.from_name(requirement.name)
+        req_dist = importlib_metadata.Distribution.from_name(requirement.name)
     except importlib_metadata.PackageNotFoundError:
         logger.info("Cannot import %s, skipping", requirement.name)
         return None


### PR DESCRIPTION
There's not need to enforce this, if someone wants to check if a list of dependencies are used in some list of files then let them without a distribution.