### PR TITLE
Add logging for file discovery

### DIFF
--- a/tests/files_test.py
+++ b/tests/files_test.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -82,3 +83,37 @@ def test_find_files(tmpdir, paths, include, exclude, expected):
 
     assert len(got) == len(expected)
     assert set(got) == set(tmpdir.join(path) for path in expected)
+
+
+def test_find_files_logs_on_excluded_directory(tmpdir, caplog):
+    dirname = "dir"
+    tmpdir.join(dirname).ensure_dir()
+
+    with caplog.at_level(logging.DEBUG):
+        got = tuple(find_files(tmpdir, exclude=(dirname,), include=()))
+
+    assert got == ()
+    assert caplog.record_tuples == [
+        (
+            "unused-deps",
+            logging.DEBUG,
+            f"Excluding directory: {os.path.join(tmpdir, dirname)}",
+        )
+    ]
+
+
+def test_find_files_logs_on_excluded_file(tmpdir, caplog):
+    filename = "file.py"
+    tmpdir.join(filename).ensure()
+
+    with caplog.at_level(logging.DEBUG):
+        got = tuple(find_files(tmpdir, exclude=(filename,), include=()))
+
+    assert got == ()
+    assert caplog.record_tuples == [
+        (
+            "unused-deps",
+            logging.DEBUG,
+            f"Excluding file: {os.path.join(tmpdir, filename)}",
+        )
+    ]

--- a/tests/import_finder_test.py
+++ b/tests/import_finder_test.py
@@ -1,3 +1,4 @@
+import logging
 from textwrap import dedent
 
 import pytest
@@ -51,3 +52,14 @@ class TestGetImportBases:
         file.write(relative_import)
 
         assert list(get_import_bases(file)) == []
+
+    def test_logs_filename(self, tmpdir, caplog):
+        file = tmpdir.join("file.py").ensure()
+
+        with caplog.at_level(logging.DEBUG):
+            got = list(get_import_bases(file))
+
+        assert got == []
+        assert caplog.record_tuples == [
+            ("unused-deps", logging.DEBUG, f"Reading imports from: {file}")
+        ]

--- a/unused_deps/files.py
+++ b/unused_deps/files.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Generator, Sequence
 from fnmatch import fnmatch
+
+logger = logging.getLogger("unused-deps")
 
 
 def find_files(
@@ -21,12 +24,15 @@ def _walk_path(path: str, exclude: Sequence[str]) -> Generator[str, None, None]:
             for directory in tuple(sub_directories):
                 joined = os.path.join(root, directory)
                 if _exclude(joined, exclude):
+                    logger.debug("Excluding directory: %s", joined)
                     sub_directories.remove(directory)
 
             for filename in files:
                 joined = os.path.join(root, filename)
                 if not _exclude(joined, exclude):
                     yield joined
+                else:
+                    logger.debug("Excluding file: %s", joined)
     else:
         yield path
 

--- a/unused_deps/files.py
+++ b/unused_deps/files.py
@@ -5,8 +5,6 @@ from collections.abc import Generator, Sequence
 from fnmatch import fnmatch
 
 
-# TODO: default includes: *.py, *.pyi
-# TODO: default excludes: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.nox,.eggs,*.egg,.venv,venv
 def find_files(
     path: str, *, exclude: Sequence[str], include: Sequence[str]
 ) -> Generator[str, None, None]:

--- a/unused_deps/import_finder.py
+++ b/unused_deps/import_finder.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import ast
+import logging
 from collections.abc import Generator
+
+logger = logging.getLogger("unused-deps")
 
 
 def get_import_bases(path: str) -> Generator[str, None, None]:
+    logger.debug("Reading imports from: %s", path)
     with open(path) as f:
         file_contents = f.read()
 

--- a/unused_deps/main.py
+++ b/unused_deps/main.py
@@ -44,7 +44,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             logger.info("Could not find any source files")
 
         success = True
-        dists = required_dists(root_dist, args.extra) if root_dist is not None else []
+        package_dists = (
+            required_dists(root_dist, args.extra) if root_dist is not None else []
+        )
         requirement_dists = (
             (
                 dist
@@ -55,7 +57,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             else []
         )
 
-        for dist in chain(dists, requirement_dists):
+        for dist in chain(package_dists, requirement_dists):
             dist_name = dist.metadata["Name"]
             if args.ignore is not None and dist_name in args.ignore:
                 logger.info("Ignoring: %s", dist_name)

--- a/unused_deps/main.py
+++ b/unused_deps/main.py
@@ -125,13 +125,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "For example, you might want to ignore a linter that you run but don't import",
     )
     parser.add_argument(
-        "-s",
-        "--source",
-        required=False,
-        action="append",
-        help="Extra directories to scan for python files to check for dependency usage",
-    )
-    parser.add_argument(
         "-e",
         "--extra",
         required=False,


### PR DESCRIPTION
- Don't ignore useful flake8 error codes

    Fix up the freshly reported errors

- Delete outdated comment

- Update variable name

- Remove unused option

- Log on file exclusion and read

    Log at the debug level to make things easier to, well, debug