### PR TITLE
Document file discovery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,23 @@
 exclude: tests/end_to_end/data
 repos:
 -   repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-pep604,flake8-no-pep420]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.991
     hooks:
     -   id: mypy
 -   repo: https://github.com/PyCQA/isort.git
-    rev: 5.10.1
+    rev: v5.11.3
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black.git
-    rev: 22.8.0
+    rev: 22.12.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml

--- a/README.md
+++ b/README.md
@@ -17,22 +17,24 @@ $ py-unused-deps
 
 ## Usage
 
-    usage: py-unused-deps [-h] [-d DISTRIBUTION] [-v] [-i IGNORE] [-s SOURCE] [-e EXTRA] [-r REQUIREMENT]
-
+    usage: py-unused-deps [-h] [-d DISTRIBUTION] [-v] [-i IGNORE] [-e EXTRA] [-r REQUIREMENT] [--include INCLUDE] [--exclude EXCLUDE] [filepaths ...]
+    
+    positional arguments:
+      filepaths             Paths to scan for dependency usage
+    
     options:
       -h, --help            show this help message and exit
       -d DISTRIBUTION, --distribution DISTRIBUTION
                             The distribution to scan for unused dependencies
       -v, --verbose
       -i IGNORE, --ignore IGNORE
-                            Dependencies to ignore when scanning for usage. For example, you might want to ignore a linter that you run but
-                            don't import
-      -s SOURCE, --source SOURCE
-                            Extra directories to scan for python files to check for dependency usage
+                            Dependencies to ignore when scanning for usage. For example, you might want to ignore a linter that you run but don't import
       -e EXTRA, --extra EXTRA
                             Extra environment to consider when loading dependencies
       -r REQUIREMENT, --requirement REQUIREMENT
                             File listing extra requirements to scan for
+      --include INCLUDE     Pattern to match on files when measuring usage
+      --exclude EXCLUDE     Pattern to match on files or directory to exclude when measuring usage
 
 ### Distribution detection
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ By default `py-unused-deps` will scan any `pyproject.toml` or
 `setup.cfg/setup.py` file to try and detect a distribution. This may not always
 be accurate, so you can specify a distribution to scan with `--distribution`
 
+### File Discovery
+
+The positional `filepaths` provides the location to search for files. Files
+under this path are matched according to the `--include` argument. This can be
+given multiple times and arguments are used interpreted as wildcard patterns
+(specifically, they are parsed to
+[`fnmatch.fnmatch`](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch).
+The default is to include files that match against `*.py` or `*.pyi`.
+
+Files can be excluded with the `--exclude` flag, which can also be given
+multiple times. Similarly to `--include` these are interpreted as shell wildcard
+patterns, with the addition that:
+
+  - Patterns are matched against entire directory names, so `__pycache__` will
+    exclude any directory containing `__pycache__`
+  - Patterns are expanded using
+    [`os.path.abspath`](https://docs.python.org/3/library/os.path.html#os.path.abspath)
+
+The default list of exclude patterns is: `.svn`, `CVS`, `.bzr`, `.hg`, `.git`,
+`__pycache__`, `.tox`, `.nox`, `.eggs`, `*.egg`, `.venv`, `venv`,
+
 ### Extra dependencies
 
 You distribution may contain extra optional dependencies to be installed like

--- a/tests/files_test.py
+++ b/tests/files_test.py
@@ -67,6 +67,15 @@ def test_find_files_includes_bare_filename(tmpdir):
             id="Exclude directory",
         ),
         pytest.param(
+            _normalize_paths(
+                "dir/file1.py", "dir/file2.py", "dir/foo/file3.py", "foo/dir/file4.py"
+            ),
+            ("*.py",),
+            ("dir",),
+            (),
+            id="Exclude directory",
+        ),
+        pytest.param(
             _normalize_paths("dir/file1.py", "dir/file2.py", "dir2/bar.py"),
             ("*.py",),
             ("dir",),


### PR DESCRIPTION
- Docs: update usage

- Document file discovery

    Also update a test to explicitly cover exclusion behaviour when a value
    is given that matches a directory name in multiple subpaths, i.e.  that
    it is excluded in each case

- Auto-update `pre-commit`

    I.e. the results of running `pre-commit autoupdate`