### PR TITLE
Add config handling

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,137 @@
+from argparse import ArgumentParser
+
+import pytest
+
+from unused_deps.config import Config, build_config, load_config_from_file
+from unused_deps.errors import InternalError
+
+
+class TestLoadConfig:
+    def test_raises_error_when_path_given_but_no_config(self, tmpdir):
+        config_file = tmpdir.join("config.toml").ensure()
+        config_file.write("[some-other-config-section]")
+
+        with pytest.raises(InternalError) as exc:
+            load_config_from_file(str(config_file))
+
+        assert str(exc.value) == f"Could not read config from {config_file}"
+
+    def test_raises_error_when_path_contains_invalid_toml(self, tmpdir):
+        config_file = tmpdir.join("config.toml").ensure()
+        config_file.write("]] bad toml [[")
+
+        with pytest.raises(InternalError) as exc:
+            load_config_from_file(config_file)
+
+        assert str(exc.value).startswith(f"Failed to read TOML file: {config_file}:")
+
+    def test_raises_error_when_path_is_missing_config(self, tmpdir):
+        config_file = tmpdir.join("config.toml").ensure()
+        config_file.write("[tool.some-other-tool]\nverbose = 1\n")
+
+        with pytest.raises(InternalError) as exc:
+            load_config_from_file(config_file)
+
+        assert str(exc.value) == f"Could not read config from {config_file}"
+
+    def test_returns_none_when_no_config(self, tmpdir):
+        with tmpdir.as_cwd():
+            assert load_config_from_file(None) is None
+
+    def test_returns_config_loaded_from_valid_path(self, tmpdir):
+        verbosity = 1
+        config_file = tmpdir.join("config.toml").ensure()
+        config_file.write(f"[py-unused-deps]\nverbose = {verbosity}\n")
+        expected = {"verbose": verbosity}
+
+        assert load_config_from_file(config_file) == expected
+
+    def test_reads_from_configs_in_order_if_none_given(self, tmpdir):
+        unused_deps_config_verbosity = 1
+        pyproject_toml_config_verbosity = 2
+        tmpdir.join(".py-unused-deps.toml").ensure().write(
+            f"[py-unused-deps]\nverbose = {unused_deps_config_verbosity}\n"
+        )
+        tmpdir.join("pyproject.toml").ensure().write(
+            f"[tool.py-unused-deps]\nverbose = {pyproject_toml_config_verbosity}\n"
+        )
+
+        with tmpdir.as_cwd():
+            config = load_config_from_file(None)
+
+        assert config is not None
+        assert config["verbose"] == unused_deps_config_verbosity
+
+    def test_skips_unreadable_configs_if_none_given(self, tmpdir):
+        verbosity = 1
+        tmpdir.join(".py-unused-deps.toml").ensure().write("[some-other-config]")
+        tmpdir.join("pyproject.toml").ensure().write(
+            f"[tool.py-unused-deps]\nverbose = {verbosity}\n"
+        )
+
+        with tmpdir.as_cwd():
+            config = load_config_from_file(None)
+
+        assert config is not None
+        assert config["verbose"] == verbosity
+
+    def test_returns_none_when_no_path_given_and_no_config(self, tmpdir):
+        tmpdir.join(".py-unused-deps.toml").ensure().write("[some-other-config]")
+        tmpdir.join("pyproject.toml").ensure().write("[some-other-config]")
+
+        with tmpdir.as_cwd():
+            assert load_config_from_file(None) is None
+
+
+class TestBuildConfig:
+    @staticmethod
+    def _build_arg_parser():
+        parser = ArgumentParser()
+        parser.add_argument("--distribution", required=False)
+        parser.add_argument("filepaths", nargs="*")
+
+        return parser
+
+    @pytest.mark.parametrize(
+        ("args", "config_from_file", "expected_config"),
+        (
+            pytest.param(
+                [],
+                {"verbose": 2, "distribution": None},
+                Config(verbose=2, filepaths=[]),
+                id="Skips None values",
+            ),
+            pytest.param(
+                ["--distribution", "foo"],
+                {"verbose": 2},
+                Config(verbose=2, distribution="foo", filepaths=[]),
+                id="Merges values",
+            ),
+            pytest.param(
+                ["--distribution", "foo"],
+                {"distribution": "bar"},
+                Config(distribution="foo", filepaths=[]),
+                id="Prioritizes args when merging",
+            ),
+            pytest.param(
+                ["--distribution", "foo"],
+                None,
+                Config(distribution="foo", filepaths=[]),
+                id="Handles no config from file",
+            ),
+        ),
+    )
+    def test_handles_valid_configs(self, args, config_from_file, expected_config):
+        parsed_args = self._build_arg_parser().parse_args(args)
+
+        assert build_config(parsed_args, config_from_file) == expected_config
+
+    def test_raises_error_on_invalid_config_key(self):
+        invalid_key = "invalid-key"
+        args = self._build_arg_parser().parse_args([])
+        config_from_file = {invalid_key: "bar"}
+
+        with pytest.raises(InternalError) as exc:
+            build_config(args, config_from_file)
+
+        assert str(exc.value) == f"Unknown configuration values: {invalid_key}"

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/.py-unused-deps.toml
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/.py-unused-deps.toml
@@ -1,0 +1,2 @@
+[py-unused-deps]
+ignore = ["py-unused-deps-testing-bar"]

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/config-with-no-ignore.toml
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/config-with-no-ignore.toml
@@ -1,0 +1,2 @@
+[py-unused-deps]
+ignore = []

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/poetry.lock
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/poetry.lock
@@ -1,0 +1,34 @@
+[[package]]
+name = "py-unused-deps-testing-bar"
+version = "0.0.1"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "directory"
+url = "../deps/bar"
+
+[[package]]
+name = "py-unused-deps-testing-foo"
+version = "0.0.1"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "directory"
+url = "../deps/foo"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7"
+content-hash = "b38fc0952620cc3b9b389768178c2c844864db7e88e0960b19d68b28fe022913"
+
+[metadata.files]
+py-unused-deps-testing-bar = []
+py-unused-deps-testing-foo = []

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/poetry_missing_dep_with_config/__init__.py
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/poetry_missing_dep_with_config/__init__.py
@@ -1,0 +1,1 @@
+import foo

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/pyproject.toml
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "poetry-dist-missing-a-dep-with-config"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+packages = [{include = "poetry_missing_dep_with_config"}]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+py-unused-deps-testing-foo = "*"
+py-unused-deps-testing-bar = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/setup.cfg
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/setup.cfg
@@ -1,0 +1,9 @@
+[metadata]
+name = setuptools-dist-missing-a-dep-with-config
+version = 0.0.1
+
+[options]
+py_modules = setuptools_missing_dep_with_config
+install_requires =
+    py-unused-deps-testing-foo
+    py-unused-deps-testing-bar

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/setup.py
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/tests/end_to_end/data/test_pkg_missing_dep_with_config/setuptools_missing_dep_with_config.py
+++ b/tests/end_to_end/data/test_pkg_missing_dep_with_config/setuptools_missing_dep_with_config.py
@@ -1,0 +1,1 @@
+import foo

--- a/tests/end_to_end/end_to_end_test.py
+++ b/tests/end_to_end/end_to_end_test.py
@@ -214,3 +214,55 @@ def test_package_missing_dep_in_requirements_reports_missing_when_pass_requireme
     assert returncode == 1
     assert captured.out == ""
     assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+
+
+@pytest.mark.parametrize(
+    ("package_name", "filepath"),
+    (
+        (
+            "setuptools-dist-missing-a-dep-with-config",
+            "setuptools_missing_dep_with_config.py",
+        ),
+        ("poetry-dist-missing-a-dep-with-config", "poetry_missing_dep_with_config"),
+    ),
+)
+def test_package_missing_dep_follows_configured_ignore(capsys, package_name, filepath):
+    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep_with_config"
+
+    with as_cwd(package_dir):
+        returncode = main(["--distribution", package_name, filepath])
+
+    captured = capsys.readouterr()
+    assert returncode == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    ("package_name", "filepath"),
+    (
+        (
+            "setuptools-dist-missing-a-dep-with-config",
+            "setuptools_missing_dep_with_config.py",
+        ),
+        ("poetry-dist-missing-a-dep-with-config", "poetry_missing_dep_with_config"),
+    ),
+)
+def test_package_missing_dep_with_separate_config(capsys, package_name, filepath):
+    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep_with_config"
+
+    with as_cwd(package_dir):
+        returncode = main(
+            [
+                "--distribution",
+                package_name,
+                "--config",
+                "config-with-no-ignore.toml",
+                filepath,
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert returncode == 1
+    assert captured.out == ""
+    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"

--- a/unused_deps/config.py
+++ b/unused_deps/config.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import os.path
+from collections.abc import Mapping
+from itertools import chain
+from typing import Dict, NamedTuple, cast
+
+from unused_deps.compat import toml
+from unused_deps.errors import InternalError
+
+logger = logging.getLogger("unused-deps")
+
+_CONFIG_LOCATIONS = (
+    ".py-unused-deps.toml",
+    "pyproject.toml",
+)
+
+
+class Config(NamedTuple):
+    filepaths: list[str]
+    distribution: str | None = None
+    ignore: list[str] | None = None
+    extras: list[str] | None = None
+    requirements: list[str] | None = None
+    include: list[str] | None = None
+    exclude: list[str] | None = None
+    verbose: int = 0
+    config_file: str | None = None
+
+
+def build_config(
+    args: argparse.Namespace, config_from_file: Mapping[str, object] | None
+) -> Config:
+    if config_from_file is None:
+        return Config(**vars(args))
+
+    invalid_keys = tuple(key for key in config_from_file if key not in Config._fields)
+    if invalid_keys:
+        raise InternalError("Unknown configuration values: " + "\n".join(invalid_keys))
+
+    return Config(
+        **{
+            k: v
+            for (k, v) in chain(config_from_file.items(), vars(args).items())
+            if v is not None
+        }
+    )
+
+
+def load_config_from_file(path: str | None) -> dict[str, object] | None:
+    if path is not None:
+        config = _read_config(path)
+        if config is None:
+            raise InternalError(f"Could not read config from {path}")
+        else:
+            return config
+    else:
+        for location in _CONFIG_LOCATIONS:
+            if os.path.exists(location):
+                config = _read_config(location)
+                if config is not None:
+                    logger.debug("Detected config in: %s", path)
+                    return config
+    return None
+
+
+def _read_config(path: str) -> dict[str, object] | None:
+    with open(path, "rb") as f:
+        try:
+            toml_data = toml.load(f)
+        except toml.TOMLDecodeError as e:
+            raise InternalError(f"Failed to read TOML file: {path}: {e}")
+
+    if os.path.basename(path) == "pyproject.toml":
+        return cast(Dict[str, object], toml_data.get("tool", {}).get("py-unused-deps"))
+    else:
+        return toml_data.get("py-unused-deps")

--- a/unused_deps/main.py
+++ b/unused_deps/main.py
@@ -7,6 +7,7 @@ from collections.abc import Generator, Iterable, Sequence
 from itertools import chain
 
 from unused_deps.compat import importlib_metadata
+from unused_deps.config import build_config, load_config_from_file
 from unused_deps.dist_info import (
     distribution_packages,
     parse_requirement,
@@ -25,9 +26,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
-    _configure_logging(args.verbose)
 
     try:
+        config_from_file = load_config_from_file(args.config_file)
+        config = build_config(args, config_from_file)
+        _configure_logging(config.verbose)
+
         python_paths = chain.from_iterable(
             find_files(path, exclude=args.exclude, include=args.include)
             for path in args.filepaths
@@ -57,7 +61,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         for dist in chain(package_dists, requirement_dists):
             dist_name = dist.metadata["Name"]
-            if args.ignore is not None and dist_name in args.ignore:
+            if config.ignore is not None and dist_name in config.ignore:
                 logger.info("Ignoring: %s", dist_name)
                 continue
 
@@ -164,6 +168,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
         action="append",
         help="Pattern to match on files or directory to exclude when measuring usage",
+    )
+    parser.add_argument(
+        "--config-file",
+        required=False,
+        help="File to load config from",
     )
     parser.add_argument(
         "filepaths",

--- a/unused_deps/main.py
+++ b/unused_deps/main.py
@@ -41,17 +41,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         success = True
         package_dists = (
-            _requirements_from_dist(args.distribution, args.extra)
+            _requirements_from_dist(args.distribution, args.extras)
             if args.distribution is not None
             else []
         )
         requirement_dists = (
             (
                 dist
-                for dist in _read_requirements(args.requirement, args.extra)
+                for dist in _read_requirements(args.requirements, args.extras)
                 if dist is not None
             )
-            if args.requirement is not None
+            if args.requirements is not None
             else []
         )
 
@@ -128,6 +128,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         required=False,
         action="append",
         help="Extra environment to consider when loading dependencies",
+        dest="extras",
     )
     parser.add_argument(
         "-r",
@@ -135,6 +136,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         required=False,
         action="append",
         help="File listing extra requirements to scan for",
+        dest="requirements",
     )
     parser.add_argument(
         "--include",


### PR DESCRIPTION
- Rename some args

    This is just an internal renaming (i.e. users see the same flags),
    and it's just so they merge nicely with the configs

- Implement handling of config from file

    Let user's store settings in a file (".py-unused-deps.toml", or
    "pyproject.toml", or any file specified with the new "--config" flag).
    Values from command line args take precedence over values stored in the
    config.

- Add end-to-end tests using configs