### PR TITLE
Force user to declare if they provide a dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,19 @@ Find unused dependencies in your Python projects.
 This application works by inspecting the metadata of your distribution and its
 dependencies. This means the current project **must be installed** and
 `py-unused-deps` must be run from within the same environment as the project,
-and its dependencies, are installed within. For example using `setuptools`:
+and its dependencies, are installed within. For example running in on this repo:
 
 ``` console
 $ python -m venv .venv
 $ source .venv/bin/activate
-$ pip install --editable .
-$ pip install unused-deps
-$ py-unused-deps
+$ pip install .
+$ py-unused-deps --distribution py-unused-deps
 ```
 
 ## Usage
 
-    usage: py-unused-deps [-h] [-d DISTRIBUTION] [-v] [-i IGNORE] [-e EXTRAS] [-r REQUIREMENTS] [--include INCLUDE] [--exclude EXCLUDE]
-                          [--config-file CONFIG_FILE]
+    usage: py-unused-deps [-h] [-d DISTRIBUTION] [-n] [-v] [-i IGNORE] [-e EXTRAS] [-r REQUIREMENTS]
+                          [--include INCLUDE] [--exclude EXCLUDE] [--config-file CONFIG_FILE]
                           [filepaths ...]
     
     positional arguments:
@@ -28,9 +27,11 @@ $ py-unused-deps
       -h, --help            show this help message and exit
       -d DISTRIBUTION, --distribution DISTRIBUTION
                             The distribution to scan for unused dependencies
+      -n, --no-distribution
       -v, --verbose
       -i IGNORE, --ignore IGNORE
-                            Dependencies to ignore when scanning for usage. For example, you might want to ignore a linter that you run but don't import
+                            Dependencies to ignore when scanning for usage. For example, you might want to
+                            ignore a linter that you run but don't import
       -e EXTRAS, --extra EXTRAS
                             Extra environment to consider when loading dependencies
       -r REQUIREMENTS, --requirement REQUIREMENTS
@@ -39,6 +40,14 @@ $ py-unused-deps
       --exclude EXCLUDE     Pattern to match on files or directory to exclude when measuring usage
       --config-file CONFIG_FILE
                             File to load config from
+
+### Specifying a Distribution
+
+There are to ways to scan for unused dependencies, if you have an installable
+project you can specify it with the `--dependency` flag. Otherwise, if you just
+have a list Python files and some dependencies e.g. in a `requirements.txt` file
+you can use the `--no-distribution` flag. Exactly one of these flags must be
+specified.
 
 ### File Discovery
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -88,6 +88,7 @@ class TestBuildConfig:
     def _build_arg_parser():
         parser = ArgumentParser()
         parser.add_argument("--distribution", required=False)
+        parser.add_argument("--no-distribution", required=False, default=False)
         parser.add_argument("filepaths", nargs="*")
 
         return parser

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -19,10 +19,22 @@ class TestMain:
         ),
     )
     def test_logging_level_set_from_args(self, args, expected_logging_level):
-        main(args)
+        main(args + ["--no-distribution"])
 
         logger = logging.getLogger("unused-deps")
         assert logger.getEffectiveLevel() == expected_logging_level
+
+    @pytest.mark.parametrize(
+        "args", ([], ["--distribution", "some-dist", "--no-distribution"])
+    )
+    def test_failure_when_no_distribution_mode_given(self, capsys, args):
+        assert main(args) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert (
+            captured.err
+            == "Error: You must specify exactly one of '--distribution' or '--no-distribution'\n"
+        )
 
     def test_failure_when_no_package_not_installable(self, tmpdir, capsys):
         package_name = "?invalid-package-name"

--- a/unused_deps/config.py
+++ b/unused_deps/config.py
@@ -21,6 +21,7 @@ _CONFIG_LOCATIONS = (
 class Config(NamedTuple):
     filepaths: list[str]
     distribution: str | None = None
+    no_distribution: bool = False
     ignore: list[str] | None = None
     extras: list[str] | None = None
     requirements: list[str] | None = None
@@ -47,6 +48,15 @@ def build_config(
             if v is not None
         }
     )
+
+
+def validate_config(config: Config) -> None:
+    if (config.distribution is None and not config.no_distribution) or (
+        config.distribution is not None and config.no_distribution
+    ):
+        raise InternalError(
+            "You must specify exactly one of '--distribution' or '--no-distribution'"
+        )
 
 
 def load_config_from_file(path: str | None) -> dict[str, object] | None:


### PR DESCRIPTION
I'm concerned it's not entirely clear that just running `py-unused-deps` will not pick up dependencies from a distribution that may exist in the present directory, so force the user to provide exactly one flag specifying whether they intend to search a distribution or not.