### PR TITLE
Use `pre-commit` to perform the self-run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,6 @@ jobs:
           name: Run end-to-end tests
           command: pytest tests/end_to_end
 
-  self-run:
-    docker:
-      - image: cimg/python:3.10
-    steps:
-      - checkout
-      - python/install-packages: *install-args
-      - run: py-unused-deps --distribution py-unused-deps unused_deps
-
 workflows:
   test-and-lint:
     jobs:
@@ -79,4 +71,3 @@ workflows:
             parameters:
               version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       - lint
-      - self-run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# end-to-end date is just placeholder code
+# end-to-end data is just placeholder code
 exclude: tests/end_to_end/data
 repos:
 -   repo: https://github.com/PyCQA/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,11 @@ repos:
     rev: v4.4.0
     hooks:
     -   id: check-yaml
+-   repo: https://github.com/matthewhughes934/py-unused-deps
+    rev: bb14d7715ee30db3d69ffbab2f2544e3ea55ec3a
+    hooks:
+    -   id: py-unused-deps
+        args:
+          - "--distribution"
+          - "py-unused-deps"
+          - "unused_deps"

--- a/README.md
+++ b/README.md
@@ -152,3 +152,14 @@ The types of configuration variables and how they map to the flags:
   - `include` (`-i/--include`): array of strings
   - `exclude` (`-i/--exclude`): array of strings
   - `verbose` (`-v/--verbose`): integer
+
+## `pre-commit`
+
+This repo includes a [`pre-commit`](https://pre-commit.com/) hook to run
+`py-unused-deps` by default it will simply run `py-unused-deps
+--no-distribution`. Since `py-unused-deps` requires the dependencies and any
+distribution to be installed it is run as a [system
+hook](https://pre-commit.com/#system), so wherever it is run will need these
+pieces installed.
+
+See [`pre-commit-config.yaml`](.pre-commit-config.yaml) for an example usage.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build status](https://circleci.com/gh/matthewhughes934/py-unused-deps.svg?style=shield&branch=main)](https://app.circleci.com/pipelines/github/matthewhughes934/py-unused-deps?branch=main)
+[![Build
+status](https://circleci.com/gh/matthewhughes934/py-unused-deps.svg?style=shield&branch=main)](https://app.circleci.com/pipelines/github/matthewhughes934/py-unused-deps?branch=main)
 [![PyPI](https://img.shields.io/pypi/v/py-unused-deps)](https://pypi.org/project/py-unused-deps/)
 
 # py-unused-deps


### PR DESCRIPTION
- Use `pre-commit` to perform the self-run

    CI _should_ already be installing this package and then runtime
    requirements, so it should just work. There's no release tagged yet, so
    just use the commit adding the hook config as our ref.

- Reformat readme

    I should really use my pre-commit hook for this...

- Fix typo in comment in pre-commit config