### PR TITLE
Validate changelog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 exclude: tests/end_to_end/data
 repos:
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-pep604,flake8-no-pep420]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.4.1
     hooks:
     -   id: mypy
 -   repo: https://github.com/PyCQA/isort.git
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black.git
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,7 @@ repos:
     rev: v0.5.0
     hooks:
     -   id: format-markdown-docker
+-   repo: https://gitlab.com/matthewhughes/common-changelog
+    rev: v0.1.1
+    hooks:
+    -   id: validate-changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,44 @@
-# v0.3.0 - 2023-04-14
+# Changelog
 
-  - Add error when bad file path given
-      - \#19 PR
+## 0.3.0 - 2023-04-14
+
+### Changed
+
+  - Add error when bad file path given (\#19)
   - Add `--no-distribution` and ensure exactly one of this an `--distribution`
-    are specified
-      - \#18 PR
+    are specified (\#18)
 
-# v0.2.1 - 2023-04-09
+## 0.2.1 - 2023-04-09
 
-  - Add repository URL to package metadata
-      - \#16 PR
+### Added
 
-# v0.2.0 - 2023-01-15
+  - Add repository URL to package metadata (\#16)
 
-  - Add license
-      - \#13 PR
-  - Add ability to read from configuration file
-      - \#11 PR
-  - Remove (somewhat) magic distribution detection
-      - \#10 PR
-  - Make specifying a distribution optional.
-      - \#6 PR
+## 0.2.0 - 2023-01-15
+
+### Added
+
+  - Add license (\#13)
+  - Add ability to read from configuration file (\#11)
   - Add some file discovery so users can specify which files are included in a
-    distribution, rather than trying to read this from package metadata
-      - \#5 PR
+    distribution, rather than trying to read this from package metadata (\#5)
   - Add some dogfeeding by including a run of `py-unused-deps` on itself in CI
-      - \#4 PR
+    (\#4)
 
-# v0.1.0 - 2022-11-06
+### Removed
 
-  - Change distribution name from `unused-deps` to `py-unused-deps`
-      - \#3 PR
+  - Remove (somewhat) magic distribution detection (\#10)
 
-# v0.0.1 - 2022-11-06
+### Changed
 
-  - Initial release
+  - Make specifying a distribution optional (\#6)
+
+## 0.1.0 - 2022-11-06
+
+### Changed
+
+  - Change distribution name from `unused-deps` to `py-unused-deps` (\#3)
+
+## 0.0.1 - 2022-11-06
+
+Initial release


### PR DESCRIPTION
- Update change to follow common changelog spec

    This one[1]

    [1] https://common-changelog.org/#2-format

- Update pre-commit hooks

    I.e. `pre-commit autoupdate`

- Add pre-commit hook to validate changelog