### PR TITLE
Fix bad config handling

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -5,6 +5,22 @@ import pytest
 from unused_deps.config import Config, build_config, load_config_from_file
 from unused_deps.errors import InternalError
 
+default_exclude = [
+    ".svn",
+    "CVS",
+    ".bzr",
+    ".hg",
+    ".git",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    ".eggs",
+    "*.egg",
+    ".venv",
+    "venv",
+]
+default_include = ["*.py", "*.pyi"]
+
 
 class TestLoadConfig:
     def test_raises_error_when_path_given_but_no_config(self, tmpdir):
@@ -99,25 +115,46 @@ class TestBuildConfig:
             pytest.param(
                 [],
                 {"verbose": 2, "distribution": None},
-                Config(verbose=2, filepaths=[]),
+                Config(
+                    verbose=2,
+                    filepaths=["."],
+                    include=default_include,
+                    exclude=default_exclude,
+                ),
                 id="Skips None values",
             ),
             pytest.param(
                 ["--distribution", "foo"],
                 {"verbose": 2},
-                Config(verbose=2, distribution="foo", filepaths=[]),
+                Config(
+                    verbose=2,
+                    distribution="foo",
+                    filepaths=["."],
+                    include=default_include,
+                    exclude=default_exclude,
+                ),
                 id="Merges values",
             ),
             pytest.param(
                 ["--distribution", "foo"],
                 {"distribution": "bar"},
-                Config(distribution="foo", filepaths=[]),
+                Config(
+                    distribution="foo",
+                    filepaths=["."],
+                    include=default_include,
+                    exclude=default_exclude,
+                ),
                 id="Prioritizes args when merging",
             ),
             pytest.param(
                 ["--distribution", "foo"],
                 None,
-                Config(distribution="foo", filepaths=[]),
+                Config(
+                    distribution="foo",
+                    filepaths=["."],
+                    include=default_include,
+                    exclude=default_exclude,
+                ),
                 id="Handles no config from file",
             ),
         ),

--- a/tests/end_to_end/data/test_pkg_nested_with_all_deps/setup.cfg
+++ b/tests/end_to_end/data/test_pkg_nested_with_all_deps/setup.cfg
@@ -6,6 +6,9 @@ version = 0.0.1
 packages = find:
 package_dir =
     =setuptools_src
+install_requires =
+    py-unused-deps-testing-foo
+    py-unused-deps-testing-bar
 
 [options.packages.find]
 where = setuptools_src

--- a/tests/end_to_end/end_to_end_test.py
+++ b/tests/end_to_end/end_to_end_test.py
@@ -61,6 +61,33 @@ def test_simple_package_missing_dep(capsys, package_name, filepath):
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
+        ("setuptools-dist-missing-a-dep", "setuptools_missing_dep.py"),
+        ("poetry-dist-missing-a-dep", "poetry_missing_dep"),
+    ),
+)
+def test_simple_package_missing_dep_ignored(capsys, package_name, filepath):
+    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep"
+
+    with as_cwd(package_dir):
+        returncode = main(
+            [
+                "--distribution",
+                package_name,
+                "--ignore",
+                "py-unused-deps-testing-bar",
+                filepath,
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert returncode == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    ("package_name", "filepath"),
+    (
         ("setuptools-nested-dist-all-deps", "setuptools_src"),
         ("poetry-nested-dist-all-deps", "poetry_src"),
     ),
@@ -75,6 +102,33 @@ def test_setuptools_nested_with_all_deps(capsys, package_name, filepath):
     assert returncode == 0
     assert captured.out == ""
     assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    ("package_name", "filepath"),
+    (
+        ("setuptools-nested-dist-all-deps", "setuptools_src"),
+        ("poetry-nested-dist-all-deps", "poetry_src"),
+    ),
+)
+def test_setuptools_nested_with_all_deps_with_exclude(capsys, package_name, filepath):
+    package_dir = Path(__file__).parent / "data" / "test_pkg_nested_with_all_deps"
+
+    with as_cwd(package_dir):
+        returncode = main(
+            [
+                "--distribution",
+                package_name,
+                "--exclude",
+                "nested",
+                filepath,
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert returncode == 1
+    assert captured.out == ""
+    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
 
 
 def test_package_with_deps_in_tests_without_extra_source(capsys):

--- a/unused_deps/main.py
+++ b/unused_deps/main.py
@@ -34,8 +34,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         _configure_logging(config.verbose)
 
         python_paths = chain.from_iterable(
-            find_files(path, exclude=args.exclude, include=args.include)
-            for path in args.filepaths
+            find_files(path, exclude=config.exclude, include=config.include)
+            for path in config.filepaths
         )
         imported_packages = frozenset(
             chain.from_iterable(get_import_bases(path) for path in python_paths)
@@ -47,18 +47,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         success = True
 
         package_dists: Iterable[importlib.metadata.Distribution]
-        if args.distribution is not None:
-            package_dists = _requirements_from_dist(args.distribution, args.extras)
+        if config.distribution is not None:
+            package_dists = _requirements_from_dist(config.distribution, config.extras)
         else:
             package_dists = []
 
         requirement_dists = (
             (
                 dist
-                for dist in _read_requirements(args.requirements, args.extras)
+                for dist in _read_requirements(config.requirements, config.extras)
                 if dist is not None
             )
-            if args.requirements is not None
+            if config.requirements is not None
             else []
         )
 
@@ -125,7 +125,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-v",
         "--verbose",
-        default=0,
         action="count",
     )
     parser.add_argument(
@@ -155,27 +154,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--include",
         required=False,
-        default=("*.py", "*.pyi"),
         action="append",
         help="Pattern to match on files when measuring usage",
     )
     parser.add_argument(
         "--exclude",
         required=False,
-        default=(
-            ".svn",
-            "CVS",
-            ".bzr",
-            ".hg",
-            ".git",
-            "__pycache__",
-            ".tox",
-            ".nox",
-            ".eggs",
-            "*.egg",
-            ".venv",
-            "venv",
-        ),
         action="append",
         help="Pattern to match on files or directory to exclude when measuring usage",
     )
@@ -186,7 +170,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "filepaths",
-        default=".",
         nargs="*",
         help="Paths to scan for dependency usage",
     )


### PR DESCRIPTION
This is to address #29

- Fix missing deps in test package

    This meant a test was silently failing while not actually checking
    anything...

- Fix inconsistent handling between args/config

    Now build the config by combining some defaults with values from config
    and then values from args

    Move all defaulting out of `argparse` handling and into our config
    building, so that defaults from `argparse` don't stomp values from
    configs.

    Fix instances where we passed a value from `args` and not `config` in
    `main`

- Add tests for handling `--ignore` and `--exclude`

    This pieces of this behaviour were covered across unit tests, but not
    the e2e tests