### PR TITLE
More tests with config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The types of configuration variables and how they map to the flags:
 
   - `filepaths`: array of strings
   - `distribution` (`-d/--distribution`): string
+  - `no_distribution` (`-n/--no-distribution`): bool
   - `ignore` (`-i/--ignore`): array of strings
   - `extras` (`-e/--extra`): array of strings
   - `requirements` (`-r/--requirement`): array of strings

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 # Auto generated hash from ./scripts/add-dependencies-hash.sh
-# 0387ba0e3cc913af62470f6b7d4517ca46f38ad99a9d7d02a478d7eebb07ba1f
+# 382d6e08c60fd04d1bb7a7fa088a331d8538af3ed0b56089982fa624ee29052b
 pytest
 pre-commit
 coverage
 covdefaults>=2.2
 
-# end-to-end tests
 poetry
 wheel
+tomli-w

--- a/scripts/add-dependencies-hash.sh
+++ b/scripts/add-dependencies-hash.sh
@@ -6,12 +6,13 @@
 
 set -o errexit -o pipefail -o nounset
 
-install_requires="$(python -c '\
-    from configparser import ConfigParser; \
-    config = ConfigParser(); \
-    config.read("setup.cfg"); \
-    print(config["options"]["install_requires"]) \
-')"
+install_requires="$(python <<-EOF
+	from configparser import ConfigParser
+	config = ConfigParser()
+	config.read("setup.cfg")
+	print(config["options"]["install_requires"])
+EOF
+)"
 
 deps_hash="$(
     echo "$install_requires" \
@@ -20,6 +21,6 @@ deps_hash="$(
     | awk '{print $1}'
 )"
 
-printf "# Auto generated hash from $0\n# $deps_hash\n" >> requirements-dev.txt.new
-cat requirements-dev.txt >> requirements-dev.txt.new
+printf "# Auto generated hash from %s\n# %s\n" "$0" "$deps_hash">> requirements-dev.txt.new
+grep --invert-match '^#' requirements-dev.txt >> requirements-dev.txt.new
 mv requirements-dev.txt.new requirements-dev.txt

--- a/tests/end_to_end/end_to_end_test.py
+++ b/tests/end_to_end/end_to_end_test.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+import tomli_w
 
 from unused_deps.main import main
 
@@ -20,6 +21,44 @@ def as_cwd(path: Path) -> Generator[None, None, None]:
         os.chdir(cwd)
 
 
+def write_config(config: Mapping[str, object], tmpdir: str) -> Path:
+    path = Path(tmpdir) / "config.toml"
+    with open(path, "w") as f:
+        f.write(tomli_w.dumps({"py-unused-deps": config}))
+    return path
+
+
+def run_with_args(
+    capsys: pytest.CaptureFixture,
+    tmpdir: str,
+    package_name: str | None,
+    package_dir: str,
+    filepaths: list[str],
+    cmd_args: list[str] | None = None,
+    config: dict[str, object] | None = None,
+) -> tuple[int, str, str]:
+    package_path = Path(__file__).parent / "data" / package_dir
+
+    if config is not None:
+        if package_name is not None:
+            config["distribution"] = package_name
+        config_path = write_config(config, tmpdir)
+        args = ["--config", str(config_path)]
+
+    if cmd_args is not None:
+        if package_name is not None:
+            args = cmd_args + ["--distribution", package_name]
+        else:
+            args = cmd_args
+
+    with as_cwd(package_path):
+        returncode = main(args + [*filepaths])
+
+    captured = capsys.readouterr()
+    return returncode, captured.out, captured.err
+
+
+@pytest.mark.parametrize(("cmd_args", "config"), (([], None), (None, {})))
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -27,18 +66,26 @@ def as_cwd(path: Path) -> Generator[None, None, None]:
         ("poetry-dist-all-deps", "poetry_all_deps"),
     ),
 )
-def test_setuptools_with_all_deps(capsys, package_name, filepath):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_with_all_deps"
+def test_setuptools_with_all_deps(
+    capsys, tmp_path, cmd_args, config, package_name, filepath
+):
+    package_dir = "test_pkg_with_all_deps"
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, filepath])
-
-    captured = capsys.readouterr()
     assert returncode == 0
-    assert captured.out == ""
-    assert captured.err == ""
+    assert out == ""
+    assert err == ""
 
 
+@pytest.mark.parametrize(("cmd_args", "config"), (([], None), (None, {})))
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -46,18 +93,32 @@ def test_setuptools_with_all_deps(capsys, package_name, filepath):
         ("poetry-dist-missing-a-dep", "poetry_missing_dep"),
     ),
 )
-def test_simple_package_missing_dep(capsys, package_name, filepath):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep"
+def test_simple_package_missing_dep(
+    capsys, tmp_path, cmd_args, config, package_name, filepath
+):
+    package_dir = "test_pkg_missing_dep"
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, filepath])
-
-    captured = capsys.readouterr()
     assert returncode == 1
-    assert captured.out == ""
-    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+    assert out == ""
+    assert err == "No usage found for: py-unused-deps-testing-bar\n"
 
 
+@pytest.mark.parametrize(
+    ("cmd_args", "config"),
+    (
+        (["--ignore", "py-unused-deps-testing-bar"], None),
+        (None, {"ignore": "py-unused-deps-testing-bar"}),
+    ),
+)
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -65,26 +126,26 @@ def test_simple_package_missing_dep(capsys, package_name, filepath):
         ("poetry-dist-missing-a-dep", "poetry_missing_dep"),
     ),
 )
-def test_simple_package_missing_dep_ignored(capsys, package_name, filepath):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep"
+def test_simple_package_missing_dep_ignored(
+    capsys, tmp_path, package_name, filepath, cmd_args, config
+):
+    package_dir = "test_pkg_missing_dep"
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    with as_cwd(package_dir):
-        returncode = main(
-            [
-                "--distribution",
-                package_name,
-                "--ignore",
-                "py-unused-deps-testing-bar",
-                filepath,
-            ]
-        )
-
-    captured = capsys.readouterr()
     assert returncode == 0
-    assert captured.out == ""
-    assert captured.err == ""
+    assert out == ""
+    assert err == ""
 
 
+@pytest.mark.parametrize(("cmd_args", "config"), (([], None), (None, {})))
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -92,18 +153,29 @@ def test_simple_package_missing_dep_ignored(capsys, package_name, filepath):
         ("poetry-nested-dist-all-deps", "poetry_src"),
     ),
 )
-def test_setuptools_nested_with_all_deps(capsys, package_name, filepath):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_nested_with_all_deps"
+def test_setuptools_nested_with_all_deps(
+    capsys, tmp_path, cmd_args, config, package_name, filepath
+):
+    package_dir = "test_pkg_nested_with_all_deps"
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, filepath])
-
-    captured = capsys.readouterr()
     assert returncode == 0
-    assert captured.out == ""
-    assert captured.err == ""
+    assert out == ""
+    assert err == ""
 
 
+@pytest.mark.parametrize(
+    ("cmd_args", "config"),
+    ((["--exclude", "nested"], None), (None, {"exclude": ["nested"]})),
+)
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -111,54 +183,75 @@ def test_setuptools_nested_with_all_deps(capsys, package_name, filepath):
         ("poetry-nested-dist-all-deps", "poetry_src"),
     ),
 )
-def test_setuptools_nested_with_all_deps_with_exclude(capsys, package_name, filepath):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_nested_with_all_deps"
+def test_setuptools_nested_with_all_deps_with_exclude(
+    capsys, tmp_path, cmd_args, config, package_name, filepath
+):
+    package_dir = "test_pkg_nested_with_all_deps"
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    with as_cwd(package_dir):
-        returncode = main(
-            [
-                "--distribution",
-                package_name,
-                "--exclude",
-                "nested",
-                filepath,
-            ]
-        )
-
-    captured = capsys.readouterr()
     assert returncode == 1
-    assert captured.out == ""
-    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+    assert out == ""
+    assert err == "No usage found for: py-unused-deps-testing-bar\n"
 
 
-def test_package_with_deps_in_tests_without_extra_source(capsys):
+@pytest.mark.parametrize(("cmd_args", "config"), (([], None), (None, {})))
+def test_package_with_deps_in_tests_without_extra_source(
+    capsys, tmp_path, cmd_args, config
+):
+    package_dir = "test_pkg_with_dep_in_tests"
     package_name = "setuptools-dist-dep-in-tests"
-    package_dir = Path(__file__).parent / "data" / "test_pkg_with_dep_in_tests"
+    filepath = "setuptools_deps_in_tests"
 
-    with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, "setuptools_deps_in_tests"])
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    captured = capsys.readouterr()
     assert returncode == 1
-    assert captured.out == ""
-    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+    assert out == ""
+    assert err == "No usage found for: py-unused-deps-testing-bar\n"
 
 
-def test_package_with_deps_in_tests_with_extra_source(capsys):
+@pytest.mark.parametrize(("cmd_args", "config"), (([], None), (None, {})))
+def test_package_with_deps_in_tests_with_extra_source(
+    capsys, tmp_path, cmd_args, config
+):
+    package_dir = "test_pkg_with_dep_in_tests"
     package_name = "setuptools-dist-dep-in-tests"
-    package_dir = Path(__file__).parent / "data" / "test_pkg_with_dep_in_tests"
+    filepaths = ["setuptools_deps_in_tests", "tests"]
 
-    with as_cwd(package_dir):
-        returncode = main(
-            ["--distribution", package_name, "setuptools_deps_in_tests", "tests"]
-        )
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        filepaths,
+        cmd_args,
+        config,
+    )
 
-    captured = capsys.readouterr()
     assert returncode == 0
-    assert captured.out == ""
-    assert captured.err == ""
+    assert out == ""
+    assert err == ""
 
 
+@pytest.mark.parametrize(
+    ("cmd_args", "config"),
+    ((["--extra", "tests"], None), (None, {"extras": ["tests"]})),
+)
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -167,21 +260,34 @@ def test_package_with_deps_in_tests_with_extra_source(capsys):
     ),
 )
 def test_package_missing_extra_dep_fails_with_extra_specified(
-    capsys, package_name, filepath
+    capsys, tmp_path, cmd_args, config, package_name, filepath
 ):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_extra_dep"
+    package_dir = "test_pkg_missing_extra_dep"
 
-    with as_cwd(package_dir):
-        returncode = main(
-            ["--distribution", package_name, "--extra", "tests", filepath]
-        )
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    captured = capsys.readouterr()
     assert returncode == 1
-    assert captured.out == ""
-    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+    assert out == ""
+    assert err == "No usage found for: py-unused-deps-testing-bar\n"
 
 
+@pytest.mark.parametrize(
+    ("cmd_args", "config"),
+    (
+        (["--extra", "something-else"], None),
+        ([], None),
+        (None, {"extras": ["something-else"]}),
+        (None, {}),
+    ),
+)
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -189,21 +295,27 @@ def test_package_missing_extra_dep_fails_with_extra_specified(
         ("poetry-dist-missing-extra-dep", "poetry_missing_extra_dep"),
     ),
 )
-@pytest.mark.parametrize("extra_args", ([], ["--extra", "something-else"]))
 def test_package_missing_extra_dep_passes_without_extra_specificed(
-    capsys, package_name, filepath, extra_args
+    capsys, tmp_path, package_name, filepath, cmd_args, config
 ):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_extra_dep"
+    package_dir = "test_pkg_missing_extra_dep"
 
-    with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name] + extra_args + [filepath])
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    captured = capsys.readouterr()
     assert returncode == 0
-    assert captured.out == ""
-    assert captured.err == ""
+    assert out == ""
+    assert err == ""
 
 
+@pytest.mark.parametrize(("cmd_args", "config"), (([], None), (None, {})))
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -218,21 +330,31 @@ def test_package_missing_extra_dep_passes_without_extra_specificed(
     ),
 )
 def test_package_missing_dep_in_requirements_no_error_without_requirements_specified(
-    capsys, package_name, filepath
+    capsys, tmp_path, cmd_args, config, package_name, filepath
 ):
-    package_dir = (
-        Path(__file__).parent / "data" / "test_pkg_missing_dep_in_requirements"
+    package_dir = "test_pkg_missing_dep_in_requirements"
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
     )
 
-    with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, filepath])
-
-    captured = capsys.readouterr()
     assert returncode == 0
-    assert captured.out == ""
-    assert captured.err == ""
+    assert out == ""
+    assert err == ""
 
 
+@pytest.mark.parametrize(
+    ("cmd_args", "config"),
+    (
+        (["--requirement", "requirements.txt"], None),
+        (None, {"requirements": ["requirements.txt"]}),
+    ),
+)
 @pytest.mark.parametrize(
     ("package_name", "filepath"),
     (
@@ -247,27 +369,23 @@ def test_package_missing_dep_in_requirements_no_error_without_requirements_speci
     ),
 )
 def test_package_missing_dep_in_requirements_reports_missing_when_pass_requirements(
-    capsys, package_name, filepath
+    capsys, tmp_path, cmd_args, config, package_name, filepath
 ):
-    package_dir = (
-        Path(__file__).parent / "data" / "test_pkg_missing_dep_in_requirements"
+    package_dir = "test_pkg_missing_dep_in_requirements"
+
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
     )
 
-    with as_cwd(package_dir):
-        returncode = main(
-            [
-                "--distribution",
-                package_name,
-                "--requirement",
-                "requirements.txt",
-                filepath,
-            ]
-        )
-
-    captured = capsys.readouterr()
     assert returncode == 1
-    assert captured.out == ""
-    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+    assert out == ""
+    assert err == "No usage found for: py-unused-deps-testing-bar\n"
 
 
 @pytest.mark.parametrize(
@@ -280,16 +398,24 @@ def test_package_missing_dep_in_requirements_reports_missing_when_pass_requireme
         ("poetry-dist-missing-a-dep-with-config", "poetry_missing_dep_with_config"),
     ),
 )
-def test_package_missing_dep_follows_configured_ignore(capsys, package_name, filepath):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep_with_config"
+def test_package_missing_dep_follows_configured_ignore(
+    capsys, tmp_path, package_name, filepath
+):
+    package_dir = "test_pkg_missing_dep_with_config"
 
-    with as_cwd(package_dir):
-        returncode = main(["--distribution", package_name, filepath])
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        [],
+        None,
+    )
 
-    captured = capsys.readouterr()
     assert returncode == 0
-    assert captured.out == ""
-    assert captured.err == ""
+    assert out == ""
+    assert err == ""
 
 
 @pytest.mark.parametrize(
@@ -302,40 +428,47 @@ def test_package_missing_dep_follows_configured_ignore(capsys, package_name, fil
         ("poetry-dist-missing-a-dep-with-config", "poetry_missing_dep_with_config"),
     ),
 )
-def test_package_missing_dep_with_separate_config(capsys, package_name, filepath):
-    package_dir = Path(__file__).parent / "data" / "test_pkg_missing_dep_with_config"
+def test_package_missing_dep_with_separate_config(
+    capsys, tmp_path, package_name, filepath
+):
+    package_dir = "test_pkg_missing_dep_with_config"
 
-    with as_cwd(package_dir):
-        returncode = main(
-            [
-                "--distribution",
-                package_name,
-                "--config",
-                "config-with-no-ignore.toml",
-                filepath,
-            ]
-        )
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        package_name,
+        package_dir,
+        [filepath],
+        ["--config", "config-with-no-ignore.toml"],
+        None,
+    )
 
-    captured = capsys.readouterr()
     assert returncode == 1
-    assert captured.out == ""
-    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+    assert out == ""
+    assert err == "No usage found for: py-unused-deps-testing-bar\n"
 
 
-def test_script_without_package_missing_dep(capsys):
-    script_dir = Path(__file__).parent / "data" / "test_without_pkg"
+@pytest.mark.parametrize(
+    ("cmd_args", "config"),
+    (
+        (["--no-distribution", "--requirement", "requirements.txt"], None),
+        (None, {"requirements": ["requirements.txt"], "no_distribution": True}),
+    ),
+)
+def test_script_without_package_missing_dep(capsys, tmp_path, cmd_args, config):
+    package_dir = "test_without_pkg"
+    filepath = "script.py"
 
-    with as_cwd(script_dir):
-        returncode = main(
-            [
-                "--no-distribution",
-                "--requirement",
-                "requirements.txt",
-                "script.py",
-            ]
-        )
+    returncode, out, err = run_with_args(
+        capsys,
+        tmp_path,
+        None,
+        package_dir,
+        [filepath],
+        cmd_args,
+        config,
+    )
 
-    captured = capsys.readouterr()
     assert returncode == 1
-    assert captured.out == ""
-    assert captured.err == "No usage found for: py-unused-deps-testing-bar\n"
+    assert out == ""
+    assert err == "No usage found for: py-unused-deps-testing-bar\n"


### PR DESCRIPTION
- Fix dependency hash script

    * Fix indentation error in python script
    * Fix `shellcheck` warning:
      > ^-- SC2059 (info): Don't use variables in the printf format string. Use printf '..%s..' "$foo".
    * Fix hash being appended, rather than replaced

- Make all e2e tests run with args and configs

    Add a helper function for handling test runs that makes it easy to pass
    a config and/or cmd args. This should also make it easier to add tests
    that check behaviour when merging args/config.

    Required an extra dep to be able to write TOML file

- Document config for `--no-distribution`