### PR TITLE
Fix language in `pre-commit` hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: py-unused-deps
     description: Find unused Python dependencies
     entry: py-unused-deps
-    language: system
+    language: python
     always_run: true
     args:
       - "--no-distribution"


### PR DESCRIPTION
An issue was raised when moving to GHA, `pre-commit` would error on our hook like:

     py-unused-deps...........................................................Failed
    - hook id: py-unused-deps
    - exit code: 1
    Executable `py-unused-deps` not found

Which revealed this hook was using the `system` language. This worked fine locally because I had things installed while developing, and in CircleCI I assume the current package was also installed to the environment.