### PR TITLE
Fix pre commit lang

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,4 +38,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+    - name: Install self and deps
+      # so we can use the `py-unused-deps` hook
+      run: pip install .
     - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: py-unused-deps
     description: Find unused Python dependencies
     entry: py-unused-deps
-    language: python
+    language: system
     always_run: true
     args:
       - "--no-distribution"


### PR DESCRIPTION
- Install current package in `pre-commit` CI step

    So we can run our own hook

- Revert "Fix language in `pre-commit` hook"

    This reverts commit 714d308e35bab8c67cb93a3c513bbaa3de4a84d1. The
    language needs to `system` per the note in the README, since we need a
    Python env with:

    * The current package installed
    * It's dependencies installed

    But `pre-commit` will run things in its own environment