### PR TITLE
Try out `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See the docs[1] for details on the config file. I'm not sure how this will handle the local dependencies that are configured in the end-to-end tests, maybe we'll have to exclude that path? Or maybe setting `directory` to "/" will mean it only picks up the top level `pyproject.toml` and `requirements-dev.txt`

[1] https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file