### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-type: "production"
-      - dependency-type: "development"
+    groups:
+      all-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
To avoid a bunch of PRs when more than on dependency is updated. I've also removed the `dependency-type` specification, let's see if dependabot still bumps dev dependencies