### PR TITLE
Revert "Updated `dependabot` to use `pipenv`"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "pipenv"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
This reverts commit 5663ee9e8ee7de7614c308b78e87d2c94ff1c58c. Per the docs[1] the YAML value here should still be `pip`

[1] https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem