### PR TITLE
Cleanup end-to-end test setup output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "py-unused-deps"
+name = "py-unused-deps!@#@$"
 version = "0.4.2"
 authors = [
     { name = "Matthew Hughes", email = "matthewhughes934@gmail.com" },

--- a/tests/end_to_end/data/install_all.sh
+++ b/tests/end_to_end/data/install_all.sh
@@ -15,7 +15,10 @@ do
     cd -- "$pkg_dir"
     if [ -e "setup.py" ]
     then
-        python setup.py --quiet install
+        python \
+            -W 'ignore:easy_install command is deprecated' \
+            -W 'ignore:setup.py install is deprecated' \
+            setup.py --quiet install
         python setup.py --quiet clean --all
     fi
 


### PR DESCRIPTION
Silence some deprecation warnings to avoid cluttering the output. An alternative would be to move these to using `pyproject.toml`, but not bothering with that for now