### PR TITLE
Update pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 exclude: tests/end_to_end/data
 repos:
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-pep604,flake8-no-pep420]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.11.2
     hooks:
     -   id: mypy
 -   repo: https://github.com/PyCQA/isort.git
@@ -15,11 +15,11 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black.git
-    rev: 24.1.0
+    rev: 24.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: check-yaml
 -   repo: https://github.com/matthewhughes934/py-unused-deps

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,9 +4,10 @@ import importlib.metadata
 import os
 from collections.abc import Iterable, Mapping
 from io import StringIO
+from pathlib import Path
 
 
-class InMemoryDistribution(importlib.metadata.Distribution):  # type: ignore[misc,unused-ignore] # for py<3.8
+class InMemoryDistribution(importlib.metadata.Distribution):
     def __init__(self, file_lines_map: Mapping[str, Iterable[str]]) -> None:
         self.file_map = {
             filename: StringIO("\n".join(lines))
@@ -37,5 +38,5 @@ class InMemoryDistribution(importlib.metadata.Distribution):  # type: ignore[mis
         else:
             return None
 
-    def locate_file(self, path: str | os.PathLike[str]) -> os.PathLike[str]:
+    def locate_file(self, path: str | os.PathLike[str]) -> Path:
         raise NotImplementedError("Unimplemented unused abstractmethod")


### PR DESCRIPTION
- Update typing in test utils

    Remove type ignore only needed for Python 3.7 or less, since we've
    dropped support for Python 3.7.

    Fix error on return type for stubbed out function, the error was:

        tests/utils.py:40: error: Return type "PathLike[str]" of "locate_file" incompatible with return type "Path" in supertype "Distribution"  [override]

    This `SimplePath` isn't exported (but should be in the future[1]) but
    it's just a protocol implementing some bits of `pathlib.Path`[2] so drop
    that in instead.

    [1] https://github.com/python/importlib_metadata/issues/494
    [2] https://github.com/python/cpython/blob/69a4063ca516360b5eb96f5432ad9f9dfc32a72e/Lib/importlib/metadata/_meta.py#L47

- Update `pre-commit`

    Via `pre-commit autoupdate`