### PR TITLE
Various GHA fixes/improvements

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           # for convenience, install into the global env,
           # rather than wrestle with virtualenvs,
-          # e.g. for installing bigs in tests/end_to_end/data/install_all.sh
+          # e.g. for installing bits in tests/end_to_end/data/install_all.sh
           cache: pip
           cache-dependency-path: Pipfile.lock
       - name: Install pipenv

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install pipenv
         run: |
           pip install pipenv
-          pip install --requirement <(pipenv requirements --categories test-packages)
+          pip install --requirement <(pipenv requirements --categories dev-packages)
       - name: run tests
         run: coverage run --module pytest
       - name: report coverage
@@ -49,5 +49,5 @@ jobs:
       - name: Install pipenv
         run: |
           pip install pipenv
-          pip install --requirement <(pipenv requirements --categories test-packages)
+          pip install --requirement <(pipenv requirements --categories dev-packages)
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
- Fix typo in comment

- Ensure pinned dependencies installed in CI

    `test-packages` is a category defined in `pyproject.toml` but not
    `Pipfile` this meant `pipenv` was just installing with the (loose)
    constraints in `pyproject.toml` and not consistently with the locked
    versions.

    Discovered with[1] which should've failed to run on Py38 since `tomli-w`
    dropped support for that version

    [1] https://github.com/matthewhughes934/py-unused-deps/pull/79

- Update Py3.13 version in CI

    This has an official release now, so run with the latest version