### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,16 @@ description = "Find unused dependencies in your python project"
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "tomli;python_version<='3.11'",
     "packaging"

--- a/tests/dist_info_test.py
+++ b/tests/dist_info_test.py
@@ -79,9 +79,12 @@ def test_required_dist_invalid_marker(caplog):
     root_dist = InMemoryDistribution(file_lines_map)
     requirement_dist = InMemoryDistribution({"METADATA": [f"name: {package_name}"]})
 
-    with caplog.at_level(logging.INFO), mock.patch(
-        "unused_deps.dist_info.importlib.metadata.Distribution.from_name",
-        return_value=requirement_dist,
+    with (
+        caplog.at_level(logging.INFO),
+        mock.patch(
+            "unused_deps.dist_info.importlib.metadata.Distribution.from_name",
+            return_value=requirement_dist,
+        ),
     ):
         got = list(required_dists(root_dist, None))
 
@@ -103,9 +106,12 @@ def test_required_dist_invalid_selects_with_supported_extra(caplog):
     requirement_dist = InMemoryDistribution({"METADATA": [f"name: {package_name}"]})
     expected = [requirement_dist]
 
-    with caplog.at_level(logging.INFO), mock.patch(
-        "unused_deps.dist_info.importlib.metadata.Distribution.from_name",
-        return_value=requirement_dist,
+    with (
+        caplog.at_level(logging.INFO),
+        mock.patch(
+            "unused_deps.dist_info.importlib.metadata.Distribution.from_name",
+            return_value=requirement_dist,
+        ),
     ):
         got = list(required_dists(root_dist, ["foo"]))
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -66,9 +66,11 @@ class TestMain:
         mock_dist = mock.Mock(**{"from_name.return_value": root_dist})
         argv = ["--distribution", root_package, "--verbose"]
 
-        with caplog.at_level(logging.INFO), mock.patch(
-            "unused_deps.main.importlib.metadata.Distribution", mock_dist
-        ), tmpdir.as_cwd():
+        with (
+            caplog.at_level(logging.INFO),
+            mock.patch("unused_deps.main.importlib.metadata.Distribution", mock_dist),
+            tmpdir.as_cwd(),
+        ):
             returncode = main(argv)
 
         assert returncode == 0
@@ -91,12 +93,16 @@ class TestMain:
         )
         argv = ["--distribution", root_package]
 
-        with mock.patch(
-            "unused_deps.main.importlib.metadata.Distribution",
-            new=mock.Mock(**{"from_name.return_value": root_dist}),
-        ), mock.patch(
-            "unused_deps.main.required_dists", return_value=[requirement_dist]
-        ), tmpdir.as_cwd():
+        with (
+            mock.patch(
+                "unused_deps.main.importlib.metadata.Distribution",
+                new=mock.Mock(**{"from_name.return_value": root_dist}),
+            ),
+            mock.patch(
+                "unused_deps.main.required_dists", return_value=[requirement_dist]
+            ),
+            tmpdir.as_cwd(),
+        ):
             returncode = main(argv)
 
         assert returncode == 0
@@ -114,12 +120,16 @@ class TestMain:
         )
         argv = ["--distribution", root_package]
 
-        with mock.patch(
-            "unused_deps.main.importlib.metadata.Distribution",
-            new=mock.Mock(**{"from_name.return_value": root_dist}),
-        ), mock.patch(
-            "unused_deps.main.required_dists", return_value=[requirement_dist]
-        ), tmpdir.as_cwd():
+        with (
+            mock.patch(
+                "unused_deps.main.importlib.metadata.Distribution",
+                new=mock.Mock(**{"from_name.return_value": root_dist}),
+            ),
+            mock.patch(
+                "unused_deps.main.required_dists", return_value=[requirement_dist]
+            ),
+            tmpdir.as_cwd(),
+        ):
             returncode = main(argv)
 
         assert returncode == 0
@@ -133,11 +143,14 @@ class TestMain:
         )
         argv = ["--distribution", package_name]
 
-        with mock.patch(
-            "unused_deps.main.importlib.metadata.Distribution",
-            new=mock.Mock(**{"from_name.return_value": root_dist}),
-        ), mock.patch(
-            "unused_deps.main.required_dists", return_value=[requirement_dist]
+        with (
+            mock.patch(
+                "unused_deps.main.importlib.metadata.Distribution",
+                new=mock.Mock(**{"from_name.return_value": root_dist}),
+            ),
+            mock.patch(
+                "unused_deps.main.required_dists", return_value=[requirement_dist]
+            ),
         ):
             returncode = main(argv)
 
@@ -163,13 +176,16 @@ class TestMain:
         )
         argv = ["--distribution", root_package, "--ignore", unused_dep_name]
 
-        with mock.patch(
-            "unused_deps.main.importlib.metadata.Distribution",
-            new=mock.Mock(**{"from_name.return_value": root_dist}),
-        ), mock.patch(
-            "unused_deps.main.required_dists", return_value=[used_dist, unused_dist]
-        ), tmpdir.as_cwd(), caplog.at_level(
-            logging.INFO
+        with (
+            mock.patch(
+                "unused_deps.main.importlib.metadata.Distribution",
+                new=mock.Mock(**{"from_name.return_value": root_dist}),
+            ),
+            mock.patch(
+                "unused_deps.main.required_dists", return_value=[used_dist, unused_dist]
+            ),
+            tmpdir.as_cwd(),
+            caplog.at_level(logging.INFO),
         ):
             returncode = main(argv)
 
@@ -192,11 +208,14 @@ class TestMain:
         )
         argv = ["--distribution", package_name, "--requirement", str(requirements_txt)]
 
-        with mock.patch(
-            "unused_deps.main.importlib.metadata.Distribution",
-            new=mock.Mock(**{"from_name.return_value": root_dist}),
-        ), mock.patch(
-            "unused_deps.main.parse_requirement", return_value=requirement_dist
+        with (
+            mock.patch(
+                "unused_deps.main.importlib.metadata.Distribution",
+                new=mock.Mock(**{"from_name.return_value": root_dist}),
+            ),
+            mock.patch(
+                "unused_deps.main.parse_requirement", return_value=requirement_dist
+            ),
         ):
             returncode = main(argv)
 


### PR DESCRIPTION
This version has reached it's end-of-life[1]

[1] https://devguide.python.org/versions/